### PR TITLE
fix: Allow is_warden to consider AW2 and AW3

### DIFF
--- a/managers/services.py
+++ b/managers/services.py
@@ -47,7 +47,9 @@ def is_warden(person, hostel_code):
     if role is not None:
         return role.designation == designations.WARDEN \
             or role.designation == designations.CHIEF_WARDEN \
-            or role.designation == designations.ASSISTANT_WARDEN
+            or role.designation == designations.ASSISTANT_WARDEN \
+            or role.designation == designations.ASSISTANT_WARDEN_2 \
+            or role.designation == designations.ASSISTANT_WARDEN_3
     return False
 
 def is_hostel_admin(person, hostel_code):


### PR DESCRIPTION
This PR fixes `is_warden()` to consider `ASSISTANT_WARDEN_2` and `ASSISTANT_WARDEN_3`