### PR TITLE
Fix/duplicate registration

### DIFF
--- a/views/resident.py
+++ b/views/resident.py
@@ -89,6 +89,16 @@ class ResidentViewset(viewsets.ModelViewSet):
                 "Residence doesn't exist !",
                 status=status.HTTP_404_NOT_FOUND,
             )
+
+        if Resident.objects.filter(
+            person=person,
+            hostel=hostel,
+            is_resident=True,
+        ).exists():
+            return Response(
+                "Student is already registered in this bhawan.",
+                status=status.HTTP_409_CONFLICT,
+            )
             
         is_living_in_campus = True
         try:


### PR DESCRIPTION
This pull request improves the resident registration process and enhances filtering functionality in the `resident.py` views. The main changes include preventing duplicate resident registrations and allowing filtering by multiple hostels.

Resident registration validation:

* Added a check in the `create` method to prevent registering a student as a resident in a hostel if they are already registered there, returning a `409 CONFLICT` response if attempted.

Filtering improvements:

* Updated the `apply_filters` method to allow filtering residents by multiple hostels using a comma-separated list in the `hostel` query parameter.